### PR TITLE
#67 Project Page styling

### DIFF
--- a/assets/css/components/_Buttons.scss
+++ b/assets/css/components/_Buttons.scss
@@ -13,6 +13,10 @@
     font-weight: $global-weight-normal;
     margin-left: $global-margin-tiny;
   }
+  .ButtonLink--textRight {
+    font-weight: $global-weight-normal;
+    margin-right: $global-margin-tiny;
+  }
 }
 .rev-ButtonGroup {
   .rev-Button {

--- a/lib/incentivize_web/templates/repository/show.html.eex
+++ b/lib/incentivize_web/templates/repository/show.html.eex
@@ -1,15 +1,43 @@
-<div>
-  <div>
+<div class="rev-Row">
+  <div class="rev-Col">
 
     <div class="rev-Row">
-      <div class="rev-Col rev-Col--medium7 rev-Col--smallCentered">
-        <h1><%= @repository.owner %>/<%= @repository.name %></h1>
+      <div class="rev-Col rev-Col--medium9 rev-Col--smallCentered">
+        <h2>Project Details</h2>
 
-        <p></p>
+        <div class="rev-Card rev-CardLayout">
 
-        <p>
-          Go to <a href="https://github.com/<%= @repository.owner %>/<%= @repository.name %>">GitHub Repo</a>.
-        </p>
+          <div class="rev-Card-header rev-CardLayout-bar">
+            <div class="rev-Row">
+              <div class="rev-Col">
+
+                <h3 class="ButtonLink">
+                  <img alt="Repo Favicon" src="/favicon.ico" />
+                  <div class="ButtonLink--header">
+                    <%= @repository.owner %>/<%= @repository.name %>
+                  </div>
+                </h3>
+
+                <p></p>
+
+              </div>
+            </div>
+          </div>
+
+          <div class="rev-Card-footer">
+            <div class="rev-Row">
+              <div class="rev-Col">
+                <div class="u-flexAlignEnd">
+                  <a class="ButtonLink" href="https://github.com/<%= @repository.owner %>/<%= @repository.name %>" target="_blank">
+                    <p class="ButtonLink--textRight">GitHub Repo</p><i class="material-icons">arrow_forward</i>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
       </div>
     </div>
 


### PR DESCRIPTION
Connect #67 

- Styled what we have so far for the Project Page details
- I added placeholder text to show what the Card would look like with a description, but removed before pushing my edits up since we don't have that hooked up yet

**Note**:
There are more sections to add to this page but they are not yet set up. To save time (since I am tight on time this week), I only styled what we are showing currently/didn't add anything to the styleguide

<img width="1280" alt="screen shot 2018-08-13 at 12 39 23 pm" src="https://user-images.githubusercontent.com/14582709/44048241-6fd63dd4-9ef6-11e8-97e1-eea2f9fba2a6.png">
<img width="401" alt="screen shot 2018-08-13 at 12 39 30 pm" src="https://user-images.githubusercontent.com/14582709/44048242-6feb9cc4-9ef6-11e8-8511-c945dcb4f7ec.png">

Without a description:
<img width="1278" alt="screen shot 2018-08-13 at 12 40 00 pm" src="https://user-images.githubusercontent.com/14582709/44048244-7001fcc6-9ef6-11e8-99be-bbd1f434f6fc.png">
