### PR TITLE
Redirect user to home with helpful message on unauthorized

### DIFF
--- a/lib/incentivize_web/plugs/require_auth.ex
+++ b/lib/incentivize_web/plugs/require_auth.ex
@@ -4,6 +4,8 @@ defmodule IncentivizeWeb.RequireAuth do
   """
 
   import Plug.Conn
+  alias IncentivizeWeb.Router.Helpers
+  alias Phoenix.Controller
 
   def init(opts) do
     opts
@@ -13,8 +15,9 @@ defmodule IncentivizeWeb.RequireAuth do
     case conn.assigns.current_user do
       nil ->
         conn
-        |> send_resp(403, "Unauthorized")
-        |> halt()
+        |> Controller.put_flash(:error, "Please log in before accessing requested page.")
+        |> Controller.redirect(to: Helpers.page_path(conn, :index))
+        |> halt
 
       _user ->
         conn

--- a/test/incentivize_web/controllers/github_auth_controller_test.exs
+++ b/test/incentivize_web/controllers/github_auth_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule IncentivizeWeb.GithubAuthController.Test do
-    @moduledoc false
- use IncentivizeWeb.ConnCase, async: true
+  @moduledoc false
+  use IncentivizeWeb.ConnCase, async: true
 
   test "GET /auth/github", %{conn: conn} do
     conn = get(conn, github_auth_path(conn, :index))
@@ -9,7 +9,7 @@ defmodule IncentivizeWeb.GithubAuthController.Test do
 
   test "GET /auth/delete when logged out", %{conn: conn} do
     conn = get(conn, github_auth_path(conn, :delete))
-    assert response(conn, 403) =~ "Unauthorized"
+    assert redirected_to(conn) =~ page_path(conn, :index)
   end
 
   test "GET /session/delete when logged in", %{conn: conn} do


### PR DESCRIPTION
connect #140 

#### Description: <!-- What changed? Why? -->
- When a user is logged out and encounters a page that needs 

<img width="1274" alt="screen shot 2018-08-15 at 12 35 33 pm" src="https://user-images.githubusercontent.com/1257573/44163594-780ece00-a089-11e8-8789-4f5d23169f29.png">
