### PR TITLE
Add instructions for creating a stellar account

### DIFF
--- a/lib/incentivize_web/templates/account/edit.html.eex
+++ b/lib/incentivize_web/templates/account/edit.html.eex
@@ -23,6 +23,7 @@
               placeholder: "example: GCEXAMPLE5HWNK4AYSTEQ4UWDKHTCKADVS2AHF3UI2ZMO3DPUSM6Q4UG"
             ) %>
             <%= error_tag f, :stellar_public_key %>
+            <span>Don't have a stellar account? You can create one <a href="<%= stellar_account_creation_link(Incentivize.Stellar.test_network?()) %>" target="_blank">here</a></span>
           </label>
 
           <section class="u-noBorder-bottom">

--- a/lib/incentivize_web/views/account_view.ex
+++ b/lib/incentivize_web/views/account_view.ex
@@ -1,3 +1,11 @@
 defmodule IncentivizeWeb.AccountView do
   use IncentivizeWeb, :view
+
+  def stellar_account_creation_link(is_test_network?) do
+    if is_test_network? do
+      "https://www.stellar.org/laboratory/#account-creator"
+    else
+      "https://www.stellar.org/account-viewer/#!/"
+    end
+  end
 end

--- a/test/incentivize_web/views/account_view_test.exs
+++ b/test/incentivize_web/views/account_view_test.exs
@@ -1,0 +1,13 @@
+defmodule IncentivizeWeb.AccountViewTest do
+  @moduledoc false
+  use IncentivizeWeb.ConnCase, async: true
+  alias IncentivizeWeb.AccountView
+
+  test "stellar_account_creation_link" do
+    assert AccountView.stellar_account_creation_link(true) ==
+             "https://www.stellar.org/laboratory/#account-creator"
+
+    assert AccountView.stellar_account_creation_link(false) ==
+             "https://www.stellar.org/account-viewer/#!/"
+  end
+end


### PR DESCRIPTION
connect #89 

#### Description: 
- When on testnet, directs users to `https://www.stellar.org/laboratory/#account-creator` to create account
- When on real network, directs users to `https://www.stellar.org/account-viewer/#!/` to create account

<img width="686" alt="screen shot 2018-08-15 at 5 58 56 pm" src="https://user-images.githubusercontent.com/1257573/44177849-4d3a6f00-a0b5-11e8-986f-fdb927118b71.png">
