### PR TITLE
Turn the repo name into a link to get back to the project

### DIFF
--- a/lib/incentivize/funds/fund.ex
+++ b/lib/incentivize/funds/fund.ex
@@ -5,7 +5,7 @@ defmodule Incentivize.Fund do
 
   use Ecto.Schema
   import Ecto.{Query, Changeset}, warn: false
-  alias Incentivize.{Fund, Pledge, Repository}
+  alias Incentivize.{Fund, Pledge, Repository, User, UserFund}
   require Logger
 
   @type t :: %__MODULE__{}
@@ -13,6 +13,7 @@ defmodule Incentivize.Fund do
     field(:stellar_public_key, :string)
     belongs_to(:repository, Repository)
     has_many(:pledges, Pledge)
+    many_to_many(:supporters, User, join_through: UserFund)
     timestamps()
   end
 

--- a/lib/incentivize/funds/funds.ex
+++ b/lib/incentivize/funds/funds.ex
@@ -45,7 +45,7 @@ defmodule Incentivize.Funds do
     Fund
     |> where([f], f.repository_id == ^repository.id)
     |> order_by([f], f.inserted_at)
-    |> preload([:pledges])
+    |> preload([:pledges, :supporters])
     |> Repo.all()
   end
 

--- a/lib/incentivize_web/templates/fund/index.html.eex
+++ b/lib/incentivize_web/templates/fund/index.html.eex
@@ -22,7 +22,7 @@
                       <img alt="Repo Favicon" src="/images/favicon.ico" />
                       <div class="ButtonLink--header">
                         <a href="<%= fund_path(@conn, :show, @repository.owner, @repository.name, fund.id) %>">
-                          <%= fund.supporter.github_login %>'s Fund
+                          <%= hd(fund.supporters).github_login %>'s Fund
                         </a>
                       </div>
                     </h3>

--- a/lib/incentivize_web/templates/fund/show.html.eex
+++ b/lib/incentivize_web/templates/fund/show.html.eex
@@ -3,7 +3,7 @@
 
     <div class="rev-Row">
       <div class="rev-Col rev-Col--medium9 rev-Col--smallCentered">
-        <h1>Fund for <%= @repository.owner %>/<%= @repository.name %></h1>
+        <h1>Fund for <a href="<%= repository_path(@conn, :show, @repository.owner, @repository.name) %>"><%= @repository.owner %>/<%= @repository.name %></a></h1>
 
         <div class="rev-Card">
           <div class="rev-Card-body">


### PR DESCRIPTION
connect #183 

- Turn the repo name into a link to get back to the project
- Fixes a bug with showing the supporter who created the fund

<img width="833" alt="screen shot 2018-09-17 at 1 58 44 pm" src="https://user-images.githubusercontent.com/1257573/45643985-03f98880-ba82-11e8-9456-27401f8a5f9f.png">
