### PR TITLE
Update the look of the repository dashboard

### DIFF
--- a/lib/incentivize/repos/repositories.ex
+++ b/lib/incentivize/repos/repositories.ex
@@ -61,6 +61,59 @@ defmodule Incentivize.Repositories do
     |> Repo.get(id)
   end
 
+  @doc """
+  Stats include:
+
+  - the number of assets distributed
+  - number of Funds created
+  - the total number of contributions
+  - the total number of contributors
+  """
+  def get_repository_stats(repository) do
+    query =
+      from(
+        contribution in Incentivize.Contribution,
+        where: contribution.repository_id == ^repository.id,
+        select: sum(contribution.amount)
+      )
+
+    number_of_assets_distributed = Repo.one(query) || 0
+
+    query =
+      from(
+        fund in Incentivize.Fund,
+        where: fund.repository_id == ^repository.id,
+        select: count(fund.id)
+      )
+
+    number_of_funds_created = Repo.one(query) || 0
+
+    query =
+      from(
+        contribution in Incentivize.Contribution,
+        where: contribution.repository_id == ^repository.id,
+        select: count(contribution.id)
+      )
+
+    number_of_contributions = Repo.one(query) || 0
+
+    query =
+      from(
+        contribution in Incentivize.Contribution,
+        where: contribution.repository_id == ^repository.id,
+        select: count(contribution.user_id, :distinct)
+      )
+
+    number_of_contributors = Repo.one(query) || 0
+
+    %{
+      number_of_assets_distributed: number_of_assets_distributed,
+      number_of_funds_created: number_of_funds_created,
+      number_of_contributions: number_of_contributions,
+      number_of_contributors: number_of_contributors
+    }
+  end
+
   def user_owns_repository?(repository, user) do
     result =
       UserRepository

--- a/lib/incentivize_web/controllers/repository_controller.ex
+++ b/lib/incentivize_web/controllers/repository_controller.ex
@@ -53,7 +53,9 @@ defmodule IncentivizeWeb.RepositoryController do
         :not_found
 
       repository ->
-        render(conn, "show.html", repository: repository)
+        stats = Repositories.get_repository_stats(repository)
+
+        render(conn, "show.html", repository: repository, stats: stats)
     end
   end
 

--- a/lib/incentivize_web/templates/repository/show.html.eex
+++ b/lib/incentivize_web/templates/repository/show.html.eex
@@ -3,42 +3,55 @@
 
     <div class="rev-Row">
       <div class="rev-Col rev-Col--medium9 rev-Col--smallCentered">
-        <h2>Project Details</h2>
+        <h2>
+          <a href="https://github.com/<%= @repository.owner %>/<%= @repository.name %>" target="_blank" rel="noreferrer">
+            <%= @repository.owner %>/<%= @repository.name %>
+          </a>
+        </h2>
 
         <div class="rev-Card rev-CardLayout">
-
           <div class="rev-Card-header rev-CardLayout-bar">
             <div class="rev-Row">
               <div class="rev-Col">
-
-                <h3 class="ButtonLink">
-                  <img alt="Repo Favicon" src="/images/favicon.ico" />
-                  <div class="ButtonLink--header u-truncate">
-                    <%= @repository.owner %>/<%= @repository.name %>
+                <div class="rev-Row">
+                  <div class="rev-Col rev-Col--medium3 Text-center">
+                    <h3>Contributions</h3>
+                    <span><%= @stats.number_of_contributions %></span>
                   </div>
-                </h3>
-
-                <p>
-                  <a href="<%= contribution_path(@conn, :for_repository, @repository.owner, @repository.name) %>">
-                    <%= length(@repository.contributions) %> Contributions
-                  </a>
-                </p>
-
-                <a class="ButtonLink" href="<%= fund_path(@conn, :index, @repository.owner, @repository.name) %>">
-                  <p class="ButtonLink--textRight">All Project Funds</p><i class="material-icons">share</i>
-                </a>
+                  <div class="rev-Col rev-Col--medium3 Text-center">
+                    <h3>Contributors</h3>
+                    <span><%= @stats.number_of_contributors %></span>
+                  </div>
+                  <div class="rev-Col rev-Col--medium2 Text-center">
+                    <h3>Funds</h3>
+                    <span><%= @stats.number_of_funds_created %></span>
+                  </div>
+                  <div class="rev-Col rev-Col--medium4 Text-center">
+                    <h3>Assets Given</h3>
+                    <span><%= @stats.number_of_assets_distributed %> <%= Incentivize.Stellar.asset_display() %></span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
 
           <div class="rev-Card-footer">
-            <div class="rev-Row">
+            <div class="rev-Row rev-Row--flex">
               <div class="rev-Col">
-                <div class="u-flexAlignEnd">
-                  <a class="ButtonLink" href="https://github.com/<%= @repository.owner %>/<%= @repository.name %>" target="_blank" rel="noreferrer">
-                    <p class="ButtonLink--textRight">GitHub Repo</p><i class="material-icons">arrow_forward</i>
-                  </a>
-                </div>
+                <a class="ButtonLink" href="<%= fund_path(@conn, :index, @repository.owner, @repository.name) %>">
+                  <div class="ButtonLink">
+                    <i class="material-icons">share</i>
+                    <p class="ButtonLink--text">View Project Funds</p>
+                  </div>
+                </a>
+              </div>
+              <div class="rev-Col rev-Col--shrink">
+                <a href="<%= contribution_path(@conn, :for_repository, @repository.owner, @repository.name) %>">
+                  <div class="ButtonLink">
+                    <i class="material-icons">screen_share</i>
+                    <p class="ButtonLink--text">View Contributions</p>
+                  </div>
+                </a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
connect #175 

#### Description: 
Updates the look of the repository dashboard by adding:
- the number of assets distributed
- number of Funds created
- the total number of contributions
- the total number of contributors


<img width="880" alt="screen shot 2018-09-18 at 9 21 06 am" src="https://user-images.githubusercontent.com/1257573/45694262-8044a800-bb24-11e8-85fd-f189f968a3cc.png">


