### PR TITLE
Move GitHub sync button and give context to how to add repos

### DIFF
--- a/lib/incentivize_web/controllers/account_controller.ex
+++ b/lib/incentivize_web/controllers/account_controller.ex
@@ -48,7 +48,7 @@ defmodule IncentivizeWeb.AccountController do
     Users.get_user_github_data(conn.assigns.current_user)
 
     conn
-    |> put_flash(:info, "GitHub Data Synced")
-    |> redirect(to: account_path(conn, :show))
+    |> put_flash(:info, "Organizations Synced")
+    |> redirect(to: repository_path(conn, :new))
   end
 end

--- a/lib/incentivize_web/templates/account/show.html.eex
+++ b/lib/incentivize_web/templates/account/show.html.eex
@@ -20,14 +20,6 @@
             <label class="rev-InputStack rev-InputLabel">
               <a href="<%= account_path(@conn, :edit) %>">Edit Account</a>
             </label>
-
-            <label class="rev-InputStack rev-InputLabel">
-                <a
-                  href="<%= account_path(@conn, :sync) %>"
-                >
-                  Sync GitHub Data
-                </a>
-            </label>
           </div>
         </div>
       </div>

--- a/lib/incentivize_web/templates/repository/_installation.html.eex
+++ b/lib/incentivize_web/templates/repository/_installation.html.eex
@@ -1,3 +1,4 @@
+<hr/>
 <div class="rev-Row">
   <div class="rev-Col">
     <div class="rev-Row">
@@ -17,7 +18,6 @@
           </a>
       </div>
     </div>
-    <hr/>
     <div class="rev-Row">
       <div class="rev-Col">
       <%= if Enum.empty?(@repositories) do %>

--- a/lib/incentivize_web/templates/repository/settings.html.eex
+++ b/lib/incentivize_web/templates/repository/settings.html.eex
@@ -3,7 +3,11 @@
 
     <div class="rev-Row">
       <div class="rev-Col rev-Col--smallCentered">
-        <h2>Settings</h2>
+        <h2>Connect Repositories</h2>
+        <p>
+          To connect repositories to Incentivize, install the Github App for you or for any GitHub Organization you are apart of.
+          During installation, you will be able to choose which repos to add or remove from Incentivize.
+        </p>
         <%= render "_installation.html",
           conn: @conn,
           name: @conn.assigns.current_user.github_login,
@@ -14,6 +18,14 @@
         %>
 
       <h3>Organizations</h3>
+        <a
+          href="<%= account_path(@conn, :sync) %>"
+          class="rev-Button"
+          title="Not seeing your organizations? Click here to resync organizations"
+        >
+          Sync Organizations
+        </a>
+        <div>Not seeing your organizations? Click above to resync organizations</div>
       <%= for org <- @organization_installation_info do %>
         <%= render "_installation.html",
           conn: @conn,

--- a/test/incentivize_web/controllers/account_controller_test.exs
+++ b/test/incentivize_web/controllers/account_controller_test.exs
@@ -33,7 +33,7 @@ defmodule IncentivizeWeb.AccountControllerTest do
 
   test "GET /account/github/sync", %{conn: conn} do
     conn = get(conn, account_path(conn, :sync))
-    assert redirected_to(conn) =~ account_path(conn, :show)
+    assert redirected_to(conn) =~ repository_path(conn, :new)
   end
 
   test "PUT /account/edit", %{conn: conn, user: user} do


### PR DESCRIPTION
connect #217 

#### Description:
- Remove Sync GitHub data link from Account page
- Add Sync Organizations button to Connect Repositories page

<img width="1121" alt="screen shot 2018-09-24 at 11 17 29 am" src="https://user-images.githubusercontent.com/1257573/45964589-db2a4380-bfeb-11e8-9213-d478883bb1f6.png">

<img width="1149" alt="screen shot 2018-09-24 at 11 13 38 am" src="https://user-images.githubusercontent.com/1257573/45964593-dd8c9d80-bfeb-11e8-8bdf-406b89c22f2b.png">


#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
