### PR TITLE
Add edit page for projects

### DIFF
--- a/lib/incentivize/github/app.ex
+++ b/lib/incentivize/github/app.ex
@@ -106,10 +106,9 @@ defmodule Incentivize.Github.App do
     |> Base.process_response()
   end
 
-  @spec list_user_private_repos(User.t()) :: {:ok, map} | {:error, binary}
-  def list_user_private_repos(user) do
-    url =
-      "#{Base.base_url()}/user/repos?visibility=private&access_token=#{user.github_access_token}"
+  @spec list_user_repos(User.t()) :: {:ok, map} | {:error, binary}
+  def list_user_repos(user) do
+    url = "#{Base.base_url()}/user/repos?access_token=#{user.github_access_token}"
 
     url
     |> HTTPoison.get(Base.headers())

--- a/lib/incentivize/users/users.ex
+++ b/lib/incentivize/users/users.ex
@@ -60,10 +60,10 @@ defmodule Incentivize.Users do
           String.downcase(org1.login) < String.downcase(org2.login)
         end)
 
-      {:ok, private_repos} = App.github_app_module().list_user_private_repos(user)
+      {:ok, repos} = App.github_app_module().list_user_repos(user)
 
-      private_repos =
-        private_repos
+      repos =
+        repos
         |> Enum.map(fn repo ->
           %{
             full_name: repo["full_name"],
@@ -78,7 +78,7 @@ defmodule Incentivize.Users do
           github_id: github_user["id"]
         },
         organizations: organizations,
-        private_repos: private_repos
+        repos: repos
       }
     end)
   end

--- a/lib/incentivize_web/controllers/account_controller.ex
+++ b/lib/incentivize_web/controllers/account_controller.ex
@@ -49,6 +49,6 @@ defmodule IncentivizeWeb.AccountController do
 
     conn
     |> put_flash(:info, "Organizations Synced")
-    |> redirect(to: repository_path(conn, :new))
+    |> redirect(to: repository_path(conn, :settings))
   end
 end

--- a/lib/incentivize_web/router.ex
+++ b/lib/incentivize_web/router.ex
@@ -128,7 +128,9 @@ defmodule IncentivizeWeb.Router do
   scope "/repos", IncentivizeWeb do
     pipe_through([:browser, :require_auth])
 
-    get("/settings", RepositoryController, :new)
+    get("/settings", RepositoryController, :settings)
+    get("/:owner/:name/edit", RepositoryController, :edit)
+    put("/:owner/:name/edit", RepositoryController, :update)
   end
 
   scope "/repos/:owner/:name/funds", IncentivizeWeb do

--- a/lib/incentivize_web/templates/fund/new.html.eex
+++ b/lib/incentivize_web/templates/fund/new.html.eex
@@ -1,18 +1,12 @@
-<div>
-  <div>
+<div class="rev-Row">
+  <div class="rev-Col rev-Col--medium7 rev-Col--smallCentered">
 
     <div class="rev-Row">
-      <div class="rev-Col rev-Col--medium7 rev-Col--smallCentered">
-
-        <div class="rev-Row">
-          <div class="rev-Col">
-            <h2 class="u-break-word">Pledges for <%= @repository.owner %>/<%= @repository.name %></h2>
-          </div>
-        </div>
-        <%= render "form.html", changeset: @changeset, action: fund_path(@conn, :create, @repository.owner, @repository.name), create: true %>
-
+      <div class="rev-Col">
+        <h2 class="u-break-word">Pledges for <%= @repository.owner %>/<%= @repository.name %></h2>
       </div>
     </div>
+    <%= render "form.html", changeset: @changeset, action: fund_path(@conn, :create, @repository.owner, @repository.name), create: true %>
 
   </div>
 </div>

--- a/lib/incentivize_web/templates/layout/app.html.eex
+++ b/lib/incentivize_web/templates/layout/app.html.eex
@@ -110,7 +110,7 @@
                       <a href="<%= account_path(@conn, :wallet) %>">Wallet</a>
                     </li>
                     <li class="rev-Menu-item">
-                      <a href="<%= repository_path(@conn, :new) %>">Connect Repositories</a>
+                      <a href="<%= repository_path(@conn, :settings) %>">Connect Repositories</a>
                     </li>
                   <% end %>
                   <%= if logged_in?(@conn) do %>
@@ -141,7 +141,7 @@
                   <a href="<%= account_path(@conn, :wallet) %>">Wallet</a>
                 </li>
                 <li class="rev-Menu-item">
-                  <a href="<%= repository_path(@conn, :new) %>">Connect Repositories</a>
+                  <a href="<%= repository_path(@conn, :settings) %>">Connect Repositories</a>
                 </li>
               <% end %>
               <%= if logged_in?(@conn) do %>

--- a/lib/incentivize_web/templates/repository/_installation.html.eex
+++ b/lib/incentivize_web/templates/repository/_installation.html.eex
@@ -33,6 +33,11 @@
               <i class="material-icons">lock</i>
             <% end %>
           </a>
+          <a
+            title="edit repository"
+            href="<%= repository_path(@conn, :edit, repo.owner, repo.name) %>">
+            <i class="material-icons">edit</i>
+          </a>
           </div>
         <% end %>
       <% end %>

--- a/lib/incentivize_web/templates/repository/edit.html.eex
+++ b/lib/incentivize_web/templates/repository/edit.html.eex
@@ -1,0 +1,10 @@
+<%= row do %>
+  <%= col class: "rev-Col--medium7 rev-Col--smallCentered" do %>
+    <%= row do %>
+      <%= col do %>
+        <h2 class="u-break-word">Edit <%= @repository.owner %>/<%= @repository.name %></h2>
+      <% end %>
+    <% end %>
+    <%= render "form.html", changeset: @changeset, action: repository_path(@conn, :update, @repository.owner, @repository.name), create: false %>
+  <% end %>
+<% end %>

--- a/lib/incentivize_web/templates/repository/form.html.eex
+++ b/lib/incentivize_web/templates/repository/form.html.eex
@@ -1,12 +1,5 @@
 <%= form_for @changeset, @action, fn f -> %>
-  <label class="rev-InputStack rev-InputLabel">
-    <span>Repository</span>
-    <%= select(f, :repo_name, @repos, class: "rev-Select", prompt: "Choose a repository", required: true) %>
-    <%= error_tag f, :owner %>
-    <%= error_tag f, :name %>
-  </label>
-
   <section class="u-noBorder-bottom">
-    <button class="rev-Button" type="submit">Connect</button>
+    <button class="rev-Button" type="submit">Update</button>
   </section>
 <% end %>

--- a/test/incentivize/github/app_test.exs
+++ b/test/incentivize/github/app_test.exs
@@ -25,7 +25,7 @@ defmodule Incentivize.Github.App.Test do
     assert {:ok, %{"login" => "octocat"}} = App.get_user(user)
   end
 
-  test "list_user_private_repos", %{bypass: bypass} do
+  test "list_user_repos", %{bypass: bypass} do
     user = insert!(:user)
     json = File.read!("./test/fixtures/list_user_repos.json")
 
@@ -33,7 +33,7 @@ defmodule Incentivize.Github.App.Test do
       Conn.resp(conn, 200, json)
     end)
 
-    assert {:ok, [_]} = App.list_user_private_repos(user)
+    assert {:ok, [_]} = App.list_user_repos(user)
   end
 
   test "list_organizations_for_user", %{bypass: bypass} do

--- a/test/incentivize_web/controllers/account_controller_test.exs
+++ b/test/incentivize_web/controllers/account_controller_test.exs
@@ -33,7 +33,7 @@ defmodule IncentivizeWeb.AccountControllerTest do
 
   test "GET /account/github/sync", %{conn: conn} do
     conn = get(conn, account_path(conn, :sync))
-    assert redirected_to(conn) =~ repository_path(conn, :new)
+    assert redirected_to(conn) =~ repository_path(conn, :settings)
   end
 
   test "PUT /account/edit", %{conn: conn, user: user} do

--- a/test/incentivize_web/controllers/repository_controller_test.exs
+++ b/test/incentivize_web/controllers/repository_controller_test.exs
@@ -63,14 +63,38 @@ defmodule IncentivizeWeb.RepositoryControllerTest do
       build_conn()
       |> assign(:current_user, user)
 
-    conn = get(conn, repository_path(conn, :new))
+    conn = get(conn, repository_path(conn, :settings))
     assert html_response(conn, 200) =~ "Connect Repositories"
     assert html_response(conn, 200) =~ "Configure"
   end
 
   test "GET /repos/settings with user who does not have installation", %{conn: conn} do
-    conn = get(conn, repository_path(conn, :new))
+    conn = get(conn, repository_path(conn, :settings))
     assert html_response(conn, 200) =~ "Connect Repositories"
     assert html_response(conn, 200) =~ "Install"
+  end
+
+  test "GET /repos/:owner/:name/edit", %{conn: conn} do
+    insert!(:repository, owner: "octocat", name: "Hello-World")
+
+    conn = get(conn, repository_path(conn, :edit, "octocat", "Hello-World"))
+    assert html_response(conn, 200) =~ "octocat/Hello-World"
+  end
+
+  test "GET /repos/:owner/:name/edit when not found", %{conn: conn} do
+    conn = get(conn, repository_path(conn, :show, "octocat", "Hello-World5"))
+    assert html_response(conn, 404)
+  end
+
+  test "PUT /repos/:owner/:name/edit", %{conn: conn} do
+    insert!(:repository, owner: "octocat", name: "Hello-World")
+
+    conn = put(conn, repository_path(conn, :edit, "octocat", "Hello-World"))
+    assert redirected_to(conn) =~ repository_path(conn, :edit, "octocat", "Hello-World")
+  end
+
+  test "PUT /repos/:owner/:name/edit when not found", %{conn: conn} do
+    conn = put(conn, repository_path(conn, :edit, "octocat", "Hello-World5"))
+    assert html_response(conn, 404)
   end
 end

--- a/test/support/mocks/github_app_mock.ex
+++ b/test/support/mocks/github_app_mock.ex
@@ -174,7 +174,7 @@ defmodule Incentivize.Github.App.Mock do
      }}
   end
 
-  def list_user_private_repos(_user) do
+  def list_user_repos(_user) do
     {:ok,
      [
        %{


### PR DESCRIPTION
connect #278 

#### Description: 
- Adds Project Edit Page
- Renames to the `new` action in repository to `settings` to match url

<img width="991" alt="screen shot 2018-10-02 at 9 47 55 am" src="https://user-images.githubusercontent.com/1257573/46358495-b0b03a00-c62c-11e8-8475-e828bc7f1438.png">

<img width="973" alt="screen shot 2018-10-02 at 9 48 15 am" src="https://user-images.githubusercontent.com/1257573/46358500-b3ab2a80-c62c-11e8-9dd4-6dee899cf733.png">


#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
