### PR TITLE
repository update/view screens

### DIFF
--- a/lib/incentivize/repos/repositories.ex
+++ b/lib/incentivize/repos/repositories.ex
@@ -77,7 +77,7 @@ defmodule Incentivize.Repositories do
         where: ilike(repo.owner, ^owner),
         where: ilike(repo.name, ^name),
         where: is_nil(repo.deleted_at),
-        preload: [:funds, :contributions]
+        preload: [:funds, :contributions, :links]
       )
 
     Repo.one(query)

--- a/lib/incentivize/repos/repositories.ex
+++ b/lib/incentivize/repos/repositories.ex
@@ -88,7 +88,7 @@ defmodule Incentivize.Repositories do
       from(repo in Repository,
         where: ilike(repo.owner, ^owner),
         where: ilike(repo.name, ^name),
-        preload: [:funds, :contributions]
+        preload: [:funds, :contributions, :links]
       )
 
     Repo.one(query)
@@ -96,7 +96,7 @@ defmodule Incentivize.Repositories do
 
   def get_repository(id) do
     Repository
-    |> preload([:funds, :contributions])
+    |> preload([:funds, :contributions, :links])
     |> Repo.get(id)
   end
 
@@ -273,6 +273,10 @@ defmodule Incentivize.Repositories do
   end
 
   def get_title(repository) do
-    "#{repository.owner}/#{repository.name}"
+    if is_nil(repository.title) do
+      "#{repository.owner}/#{repository.name}"
+    else
+      repository.title
+    end
   end
 end

--- a/lib/incentivize/repos/repository.ex
+++ b/lib/incentivize/repos/repository.ex
@@ -21,7 +21,7 @@ defmodule Incentivize.Repository do
     field(:title, :string)
     field(:logo_url, :string)
     field(:description, :string)
-    has_many(:links, RepositoryLink)
+    has_many(:links, RepositoryLink, on_replace: :delete)
   end
 
   def create_changeset(%Repository{} = model, params \\ %{}) do

--- a/lib/incentivize/repos/repository_link.ex
+++ b/lib/incentivize/repos/repository_link.ex
@@ -5,7 +5,7 @@ defmodule Incentivize.RepositoryLink do
 
   use Ecto.Schema
   import Ecto.{Query, Changeset}, warn: false
-  alias Incentivize.{Contribution, Repository, RepositoryLink}
+  alias Incentivize.{Repository, RepositoryLink}
 
   @type t :: %__MODULE__{}
   schema "repository_links" do

--- a/lib/incentivize/repos/repository_link.ex
+++ b/lib/incentivize/repos/repository_link.ex
@@ -22,6 +22,6 @@ defmodule Incentivize.RepositoryLink do
       :url,
       :repository_id
     ])
-    |> validate_required([:title, :url])
+    |> validate_required([:url])
   end
 end

--- a/lib/incentivize/stellar/stellar.ex
+++ b/lib/incentivize/stellar/stellar.ex
@@ -74,6 +74,8 @@ defmodule Incentivize.Stellar do
 
   defp generate_escrow_account_xdr do
     {escrow_public, escrow_secret} = Stellar.KeyPair.random()
+
+    # Starting balance needed for account
     starting_balance = "2.5000000"
 
     {:ok, xdr} =

--- a/lib/incentivize_web/controllers/fund_controller.ex
+++ b/lib/incentivize_web/controllers/fund_controller.ex
@@ -7,8 +7,7 @@ defmodule IncentivizeWeb.FundController do
   def index(conn, %{"owner" => owner, "name" => name}) do
     repository = Repositories.get_repository_by_owner_and_name(owner, name)
 
-    if repository != nil and
-         Repositories.can_view_repository?(repository, conn.assigns.current_user) do
+    if Repositories.can_view_repository?(repository, conn.assigns.current_user) do
       funds = Funds.list_funds_for_repository(repository)
 
       render(conn, "index.html", repository: repository, funds: funds)
@@ -20,8 +19,7 @@ defmodule IncentivizeWeb.FundController do
   def new(conn, %{"owner" => owner, "name" => name}) do
     repository = Repositories.get_repository_by_owner_and_name(owner, name)
 
-    if repository != nil and
-         Repositories.can_view_repository?(repository, conn.assigns.current_user) do
+    if Repositories.can_view_repository?(repository, conn.assigns.current_user) do
       changeset = Fund.create_changeset(%Fund{})
       render(conn, "new.html", repository: repository, changeset: changeset)
     else
@@ -32,8 +30,7 @@ defmodule IncentivizeWeb.FundController do
   def create(conn, %{"owner" => owner, "name" => name, "fund" => params}) do
     repository = Repositories.get_repository_by_owner_and_name(owner, name)
 
-    if repository != nil and
-         Repositories.can_view_repository?(repository, conn.assigns.current_user) do
+    if Repositories.can_view_repository?(repository, conn.assigns.current_user) do
       pledges = Map.get(params, "pledges", %{})
 
       pledges =

--- a/lib/incentivize_web/controllers/repository_controller.ex
+++ b/lib/incentivize_web/controllers/repository_controller.ex
@@ -95,7 +95,8 @@ defmodule IncentivizeWeb.RepositoryController do
   def update(conn, %{"owner" => owner, "name" => name, "repository" => params}) do
     repository = Repositories.get_repository_by_owner_and_name(owner, name)
 
-    links = params
+    links =
+      params
       |> Map.get("links", %{})
       |> Enum.filter(fn {_index, data} ->
         String.trim(data["url"]) != ""

--- a/lib/incentivize_web/controllers/repository_controller.ex
+++ b/lib/incentivize_web/controllers/repository_controller.ex
@@ -92,13 +92,28 @@ defmodule IncentivizeWeb.RepositoryController do
     end
   end
 
-  def update(conn, %{"owner" => owner, "name" => name}) do
+  def update(conn, %{"owner" => owner, "name" => name, "repository" => params}) do
     repository = Repositories.get_repository_by_owner_and_name(owner, name)
 
+    links = params
+      |> Map.get("links", %{})
+      |> Enum.filter(fn {_index, data} ->
+        String.trim(data["url"]) != ""
+      end)
+      |> Enum.into(%{})
+
+    params = Map.put(params, "links", links)
+
     if Repositories.can_edit_repository?(repository, conn.assigns.current_user) do
-      conn
-      |> put_flash(:info, "#{Repositories.get_title(repository)} updated.")
-      |> redirect(to: repository_path(conn, :edit, owner, name))
+      case Repositories.update_repository(repository, params) do
+        {:ok, _} ->
+          conn
+          |> put_flash(:info, "#{Repositories.get_title(repository)} updated.")
+          |> redirect(to: repository_path(conn, :edit, owner, name))
+
+        {:error, changeset} ->
+          render(conn, "edit.html", repository: repository, changeset: changeset)
+      end
     else
       :not_found
     end

--- a/lib/incentivize_web/templates/repository/edit.html.eex
+++ b/lib/incentivize_web/templates/repository/edit.html.eex
@@ -1,10 +1,6 @@
 <%= row do %>
   <%= col class: "rev-Col--medium7 rev-Col--smallCentered" do %>
-    <%= row do %>
-      <%= col do %>
-        <h2 class="u-break-word">Edit <%= @repository.owner %>/<%= @repository.name %></h2>
-      <% end %>
-    <% end %>
+    <h2 class="u-break-word Text-center">Edit <%= @repository.owner %>/<%= @repository.name %></h2>
     <%= render "form.html", changeset: @changeset, action: repository_path(@conn, :update, @repository.owner, @repository.name), create: false %>
   <% end %>
 <% end %>

--- a/lib/incentivize_web/templates/repository/edit.html.eex
+++ b/lib/incentivize_web/templates/repository/edit.html.eex
@@ -1,6 +1,10 @@
 <%= row do %>
   <%= col class: "rev-Col--medium7 rev-Col--smallCentered" do %>
-    <h2 class="u-break-word Text-center">Edit <%= @repository.owner %>/<%= @repository.name %></h2>
+    <%= row do %>
+      <%= col do %>
+        <h2 class="u-break-word">Edit <%= @repository.owner %>/<%= @repository.name %></h2>
+      <% end %>
+    <% end %>
     <%= render "form.html", changeset: @changeset, action: repository_path(@conn, :update, @repository.owner, @repository.name), create: false %>
   <% end %>
 <% end %>

--- a/lib/incentivize_web/templates/repository/form.html.eex
+++ b/lib/incentivize_web/templates/repository/form.html.eex
@@ -1,23 +1,36 @@
 <%= form_for @changeset, @action, fn f -> %>
-  <label class="rev-InputStack rev-InputLabel">
-    <span>Name</span>
-    <%= text_input(f, :title, class: "rev-Input", maxlength: 250) %>
-    <%= error_tag f, :title %>
-  </label>
+  <%= row do %>
+    <%= col do %>
+      <label class="rev-InputStack rev-InputLabel">
+        <span>Name</span>
+        <%= text_input(f, :title, class: "rev-Input", maxlength: 250) %>
+        <%= error_tag f, :title %>
+      </label>
+    <% end %>
 
-  <label class="rev-InputStack rev-InputLabel">
-    <span>Description</span>
-    <%= textarea(f, :description, class: "rev-Input") %>
-    <%= error_tag f, :description %>
-  </label>
+    <%= col do %>
+      <label class="rev-InputStack rev-InputLabel">
+        <span>Description</span>
+        <%= textarea(f, :description, class: "rev-Input") %>
+        <%= error_tag f, :description %>
+      </label>
+    <% end %>
 
-  <label class="rev-InputStack rev-InputLabel">
-    <span>Logo URL</span>
-    <%= url_input(f, :logo_url, class: "rev-Input") %>
-    <%= error_tag f, :logo_url %>
-  </label>
+    <%= col do %>
+      <label class="rev-InputStack rev-InputLabel">
+        <span>Logo URL</span>
+        <%= url_input(f, :logo_url, class: "rev-Input") %>
+        <%= error_tag f, :logo_url %>
+      </label>
+    <% end %>
+  <% end %>
 
-  <h3>Links</h3>
+  <%= row do %>
+    <%= col do %>
+      <h3>Links</h3>
+    <% end %>
+  <% end %>
+
   <%= inputs_for f, :links, [append: append_links(f.data)], fn flinks -> %>
     <%= row do %>
       <%= col medium: 6 do %>
@@ -37,7 +50,12 @@
     <% end %>
   <% end %>
 
-  <section class="u-noBorder-bottom">
-    <button class="rev-Button" type="submit">Update</button>
-  </section>
+  <%= row do %>
+    <%= col do %>
+      <section class="u-noBorder-bottom u-flexAlignEnd">
+        <button class="rev-Button" type="submit">Update</button>
+      </section>
+    <% end %>
+  <% end %>
+
 <% end %>

--- a/lib/incentivize_web/templates/repository/form.html.eex
+++ b/lib/incentivize_web/templates/repository/form.html.eex
@@ -1,4 +1,42 @@
 <%= form_for @changeset, @action, fn f -> %>
+  <label class="rev-InputStack rev-InputLabel">
+    <span>Name</span>
+    <%= text_input(f, :title, class: "rev-Input", maxlength: 250) %>
+    <%= error_tag f, :title %>
+  </label>
+
+  <label class="rev-InputStack rev-InputLabel">
+    <span>Description</span>
+    <%= textarea(f, :description, class: "rev-Input") %>
+    <%= error_tag f, :description %>
+  </label>
+
+  <label class="rev-InputStack rev-InputLabel">
+    <span>Logo URL</span>
+    <%= url_input(f, :logo_url, class: "rev-Input") %>
+    <%= error_tag f, :logo_url %>
+  </label>
+
+  <h3>Links</h3>
+  <%= inputs_for f, :links, [append: append_links(f.data)], fn flinks -> %>
+    <%= row do %>
+      <%= col medium: 6 do %>
+         <label class="rev-InputStack rev-InputLabel">
+            <span>Title</span>
+            <%= text_input(flinks, :title, class: "rev-Input", maxlength: 250) %>
+            <%= error_tag flinks, :title %>
+          </label>
+      <% end %>
+      <%= col medium: 6 do %>
+        <label class="rev-InputStack rev-InputLabel">
+          <span>URL</span>
+          <%= url_input(flinks, :url, class: "rev-Input") %>
+          <%= error_tag flinks, :url %>
+        </label>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <section class="u-noBorder-bottom">
     <button class="rev-Button" type="submit">Update</button>
   </section>

--- a/lib/incentivize_web/templates/repository/form.html.eex
+++ b/lib/incentivize_web/templates/repository/form.html.eex
@@ -18,6 +18,14 @@
 
     <%= col do %>
       <label class="rev-InputStack rev-InputLabel">
+        <span>Title</span>
+        <%= text_input(f, :title, class: "rev-Input", maxlength: 250) %>
+        <%= error_tag f, :title %>
+      </label>
+    <% end %>
+
+    <%= col do %>
+      <label class="rev-InputStack rev-InputLabel">
         <span>Logo URL</span>
         <%= url_input(f, :logo_url, class: "rev-Input") %>
         <%= error_tag f, :logo_url %>

--- a/lib/incentivize_web/templates/repository/show.html.eex
+++ b/lib/incentivize_web/templates/repository/show.html.eex
@@ -1,108 +1,74 @@
-<div class="rev-Row">
-  <div class="rev-Col">
 
-    <div class="rev-Row">
-      <div class="rev-Col rev-Col--medium9 rev-Col--smallCentered">
-        <h2>
-          <a href="https://github.com/<%= @repository.owner %>/<%= @repository.name %>" target="_blank" rel="noreferrer">
-            <%= @repository.owner %>/<%= @repository.name %>
-            <%= if @repository.public == false do %>
-              <i class="material-icons">lock</i>
-            <% end %>
-          </a>
-        </h2>
+<h2 class="Text-center"><%= get_title(@repository) %></h2>
+<%= row do %>
+  <%= col medium: 8 do %>
+    <%= if @repository.logo_url do %>
+      <img src="<%= @repository.logo_url %>" />
+    <% end %>
 
-        <div class="rev-Card rev-CardLayout">
-          <div class="rev-Card-header rev-CardLayout-bar">
-            <div class="rev-Row">
-              <div class="rev-Col">
-                <div class="rev-Row">
-                  <div class="rev-Col rev-Col--medium3 Text-center">
-                    <h3>Contributions</h3>
-                    <span><%= @stats.number_of_contributions %></span>
-                  </div>
-                  <div class="rev-Col rev-Col--medium3 Text-center">
-                    <h3>Contributors</h3>
-                    <span><%= @stats.number_of_contributors %></span>
-                  </div>
-                  <div class="rev-Col rev-Col--medium2 Text-center">
-                    <h3>Funds</h3>
-                    <span><%= @stats.number_of_funds_created %></span>
-                  </div>
-                  <div class="rev-Col rev-Col--medium4 Text-center">
-                    <h3>Assets Given</h3>
-                    <span><%= @stats.number_of_assets_distributed %> <%= Incentivize.Stellar.asset_display() %></span>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <%= row class: "Text-center" do %>
-              <%= col medium: 6 do %>
-                <h3>Most Contributions</h3>
-                <%= if Enum.empty?(@stats.most_contributions) do %>
-                  <div>No contributions</div>
-                <% else %>
-                <ol>
-                  <%= for contribution <- @stats.most_contributions do %>
-                      <li>
-                        <a href="https://github.com/<%= contribution.github_login %>">
-                          <%= contribution.github_login %> (<%= contribution.count %>)
-                        </a>
-                      </li>
-                  <% end %>
-                </ol>
-                <% end %>
-              <% end %>
-              <%= col medium: 6 do %>
-                <h3>Most Active Fund</h3>
-                <%= if Enum.empty?(@stats.most_active_funds) do %>
-                  <div>No active funds</div>
-                <% else %>
-                  <ol>
-                    <%= for fund <- @stats.most_active_funds do %>
-                      <li>
-                        <a href="<%= fund_path(@conn, :show, @repository.owner, @repository.name, fund.fund.id) %>">
-                          <%= IncentivizeWeb.FundView.fund_name(fund.fund) %> (<%= fund.sum %> <%= Incentivize.Stellar.asset_display() %>)
-                        </a>
-                      </li>
-                    <% end %>
-                  </ol>
-                <% end %>
-              <% end %>
-            <% end %>
+    <h3>Description</h3>
+    <%= if @repository.description do %>
+      <p><%= @repository.description %></p>
+    <% end %>
 
-          </div>
+  <% end %>
+  <%= col medium: 4 do %>
+    <p>
+      <a href="<%= contribution_path(@conn, :for_repository, @repository.owner, @repository.name) %>">
+        <%= @stats.number_of_contributions %> Contributions
+      </a>
+    </p>
+    <p><%= @stats.number_of_contributors %> Contributors</p>
+    <p>
+      <a href="<%= fund_path(@conn, :index, @repository.owner, @repository.name) %>">
+        <%= @stats.number_of_funds_created %> Funds
+      </a>
+    </p>
+    <p><%= @stats.number_of_assets_distributed %> <%= Incentivize.Stellar.asset_display() %> Given</p>
 
+    <a class="rev-Button rev-Button--expanded Text-center" href="https://github.com/<%= @repository.owner %>/<%= @repository.name %>" target="_blank" rel="noreferrer">
+      Contribute on GitHub
+    </a>
+    <a class="rev-Button rev-Button--expanded rev-Button--secondary Text-center" href="<%= fund_path(@conn, :new, @repository.owner, @repository.name) %>">
+      Fund this project
+    </a>
 
-          <div class="rev-Card-footer">
-            <div class="rev-Row rev-Row--flex">
-              <div class="rev-Col">
-                <a class="ButtonLink" href="<%= fund_path(@conn, :index, @repository.owner, @repository.name) %>">
-                  <div class="ButtonLink">
-                    <i class="material-icons">share</i>
-                    <p class="ButtonLink--text">View Project Funds</p>
-                  </div>
-                </a>
+    <%= for link <- @repository.links do %>
+      <p>
+        <a href="<%= link.url %>" target="_blank" rel="noreferrer">
+          <%= if link.title, do: link.title, else: link.url %>
+        </a>
+      </p>
+    <% end %>
 
-              </div>
-              <div class="rev-Col">
-                <a class="rev-Button rev-Button--secondary" href="<%= fund_path(@conn, :new, @repository.owner, @repository.name) %>">Support Project</a>
-              </div>
-              <div class="rev-Col rev-Col--shrink">
-                <a href="<%= contribution_path(@conn, :for_repository, @repository.owner, @repository.name) %>">
-                  <div class="ButtonLink">
-                    <i class="material-icons">screen_share</i>
-                    <p class="ButtonLink--text">View Contributions</p>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
+    <h3>Most Contributions</h3>
+    <%= if Enum.empty?(@stats.most_contributions) do %>
+      <div>No contributions</div>
+    <% else %>
+      <ol>
+        <%= for contribution <- @stats.most_contributions do %>
+            <li>
+              <a href="https://github.com/<%= contribution.github_login %>">
+                <%= contribution.github_login %> (<%= contribution.count %>)
+              </a>
+            </li>
+        <% end %>
+      </ol>
+    <% end %>
 
-        </div>
-
-      </div>
-    </div>
-
-  </div>
-</div>
+    <h3>Most Active Fund</h3>
+    <%= if Enum.empty?(@stats.most_active_funds) do %>
+      <div>No active funds</div>
+    <% else %>
+      <ol>
+        <%= for fund <- @stats.most_active_funds do %>
+          <li>
+            <a href="<%= fund_path(@conn, :show, @repository.owner, @repository.name, fund.fund.id) %>">
+              <%= IncentivizeWeb.FundView.fund_name(fund.fund) %> (<%= fund.sum %> <%= Incentivize.Stellar.asset_display() %>)
+            </a>
+          </li>
+        <% end %>
+      </ol>
+    <% end %>
+  <% end %>
+<% end %>

--- a/lib/incentivize_web/views/repository_view.ex
+++ b/lib/incentivize_web/views/repository_view.ex
@@ -1,6 +1,8 @@
 defmodule IncentivizeWeb.RepositoryView do
   use IncentivizeWeb, :view
   @page_links_to_show 2
+  @max_number_of_links 3
+  alias Incentivize.RepositoryLink
 
   def make_next_page_link(conn, current_page) do
     make_page_link(conn, current_page + 1)
@@ -54,5 +56,15 @@ defmodule IncentivizeWeb.RepositoryView do
 
   def show_page_link?(page, page_number) do
     page >= page_number - @page_links_to_show and page <= page_number + @page_links_to_show
+  end
+
+  def append_links(repository) do
+    links_needed = @max_number_of_links - length(repository.links)
+
+    if links_needed <= 0 do
+      []
+    else
+      Enum.map(1..links_needed, fn _ -> %RepositoryLink{} end)
+    end
   end
 end

--- a/lib/incentivize_web/views/repository_view.ex
+++ b/lib/incentivize_web/views/repository_view.ex
@@ -2,7 +2,7 @@ defmodule IncentivizeWeb.RepositoryView do
   use IncentivizeWeb, :view
   @page_links_to_show 2
   @max_number_of_links 3
-  alias Incentivize.RepositoryLink
+  alias Incentivize.{Repositories, RepositoryLink}
 
   def make_next_page_link(conn, current_page) do
     make_page_link(conn, current_page + 1)
@@ -66,5 +66,9 @@ defmodule IncentivizeWeb.RepositoryView do
     else
       Enum.map(1..links_needed, fn _ -> %RepositoryLink{} end)
     end
+  end
+
+  def get_title(repository) do
+    Repositories.get_title(repository)
   end
 end

--- a/lib/incentivize_web/views/view_helpers.ex
+++ b/lib/incentivize_web/views/view_helpers.ex
@@ -2,7 +2,7 @@ defmodule IncentivizeWeb.ViewHelpers do
   @moduledoc """
   Site-wide view functions
   """
-  alias Incentivize.User
+  alias Incentivize.{Repositories, User}
 
   @spec logged_in?(Plug.Conn.t()) :: boolean()
   def logged_in?(conn) do
@@ -20,7 +20,7 @@ defmodule IncentivizeWeb.ViewHelpers do
   end
 
   def title(IncentivizeWeb.RepositoryView, "show.html", %{repository: repository}) do
-    with_brand_name("#{repository.owner}/#{repository.name}")
+    with_brand_name(Repositories.get_title(repository))
   end
 
   def title(IncentivizeWeb.RepositoryView, "settings.html", _assigns) do
@@ -40,7 +40,7 @@ defmodule IncentivizeWeb.ViewHelpers do
   end
 
   def title(IncentivizeWeb.FundView, "index.html", %{repository: repository}) do
-    with_brand_name("#{repository.owner}/#{repository.name}'s Funds")
+    with_brand_name("#{Repositories.get_title(repository)}'s Funds")
   end
 
   def title(IncentivizeWeb.FundView, "show.html", %{fund: fund}) do

--- a/test/incentivize_web/controllers/fund_controller_test.exs
+++ b/test/incentivize_web/controllers/fund_controller_test.exs
@@ -99,7 +99,7 @@ defmodule IncentivizeWeb.FundControllerTest do
 
   test "GET /repos/:owner/:name/fund/:id when not fund owner and not logged in" do
     repository = insert!(:repository, owner: "me", name: "me")
-    fund = insert!(:fund, repository: repository)
+    fund = insert!(:fund, repository: repository, description: "A fund")
 
     conn = build_conn()
 

--- a/test/incentivize_web/controllers/repository_controller_test.exs
+++ b/test/incentivize_web/controllers/repository_controller_test.exs
@@ -89,12 +89,13 @@ defmodule IncentivizeWeb.RepositoryControllerTest do
   test "PUT /repos/:owner/:name/edit", %{conn: conn} do
     insert!(:repository, owner: "octocat", name: "Hello-World")
 
-    conn = put(conn, repository_path(conn, :edit, "octocat", "Hello-World"))
+    conn = put(conn, repository_path(conn, :edit, "octocat", "Hello-World"), repository: %{})
+
     assert redirected_to(conn) =~ repository_path(conn, :edit, "octocat", "Hello-World")
   end
 
   test "PUT /repos/:owner/:name/edit when not found", %{conn: conn} do
-    conn = put(conn, repository_path(conn, :edit, "octocat", "Hello-World5"))
+    conn = put(conn, repository_path(conn, :edit, "octocat", "Hello-World5"), repository: %{})
     assert html_response(conn, 404)
   end
 end

--- a/test/incentivize_web/controllers/repository_controller_test.exs
+++ b/test/incentivize_web/controllers/repository_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule IncentivizeWeb.RepositoryControllerTest do
   @moduledoc false
   use IncentivizeWeb.ConnCase, async: true
+  alias Incentivize.Repositories
 
   setup %{conn: conn} do
     user = insert!(:user)
@@ -51,6 +52,20 @@ defmodule IncentivizeWeb.RepositoryControllerTest do
     assert html_response(conn, 200) =~ "octocat/Hello-World"
   end
 
+  test "GET /repos/:owner/:name with title", %{conn: conn} do
+    insert!(:repository, owner: "octocat", name: "Hello-World5", title: "Hello World")
+
+    conn = get(conn, repository_path(conn, :show, "octocat", "Hello-World5"))
+    assert html_response(conn, 200) =~ "Hello World"
+  end
+
+  test "GET /repos/:owner/:name when repo private and user has access", %{conn: conn} do
+    insert!(:repository, owner: "octocat", name: "Hello-World", public: false)
+
+    conn = get(conn, repository_path(conn, :show, "octocat", "Hello-World"))
+    assert html_response(conn, 200) =~ "octocat/Hello-World"
+  end
+
   test "GET /repos/:owner/:name when not found", %{conn: conn} do
     conn = get(conn, repository_path(conn, :show, "octocat", "Hello-World5"))
     assert html_response(conn, 404)
@@ -87,11 +102,37 @@ defmodule IncentivizeWeb.RepositoryControllerTest do
   end
 
   test "PUT /repos/:owner/:name/edit", %{conn: conn} do
-    insert!(:repository, owner: "octocat", name: "Hello-World")
+    repository = insert!(:repository, owner: "octocat", name: "Hello-World")
 
-    conn = put(conn, repository_path(conn, :edit, "octocat", "Hello-World"), repository: %{})
+    params = %{
+      "description" => "This is a test",
+      "links" => %{
+        "0" => %{
+          "title" => "",
+          "url" => ""
+        },
+        "1" => %{
+          "title" => "",
+          "url" => ""
+        },
+        "2" => %{
+          "title" => "",
+          "url" => "https://google.com"
+        }
+      },
+      "logo_url" => "https://image.com/image.png",
+      "title" => "Test title"
+    }
+
+    conn = put(conn, repository_path(conn, :edit, "octocat", "Hello-World"), repository: params)
 
     assert redirected_to(conn) =~ repository_path(conn, :edit, "octocat", "Hello-World")
+
+    repo = Repositories.get_repository(repository.id)
+    assert hd(repo.links).url == "https://google.com"
+    assert repo.title == "Test title"
+    assert repo.logo_url == "https://image.com/image.png"
+    assert repo.description == "This is a test"
   end
 
   test "PUT /repos/:owner/:name/edit when not found", %{conn: conn} do


### PR DESCRIPTION
connect #258 
connect #263 
connect #257 
connect #256 

#### Description:
- Screen for updating repositories
- Initial screen for updated view of project

<img width="799" alt="screen shot 2018-10-02 at 1 21 28 pm" src="https://user-images.githubusercontent.com/1257573/46368544-1a890d80-c646-11e8-9cc9-ce29141683d0.png">

<img width="732" alt="screen shot 2018-10-02 at 1 21 23 pm" src="https://user-images.githubusercontent.com/1257573/46368547-1eb52b00-c646-11e8-899a-94069e308e36.png">

<img width="1278" alt="screen shot 2018-10-02 at 8 16 36 pm" src="https://user-images.githubusercontent.com/1257573/46414009-d5b5b300-c6e7-11e8-8178-9b5049c03636.png">


#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
