### PR TITLE
Make Stellar key optional

### DIFF
--- a/lib/incentivize_web/controllers/repository_controller.ex
+++ b/lib/incentivize_web/controllers/repository_controller.ex
@@ -81,6 +81,16 @@ defmodule IncentivizeWeb.RepositoryController do
     end
   end
 
+  def contribute(conn, %{"owner" => owner, "name" => name}) do
+    repository = Repositories.get_repository_by_owner_and_name(owner, name)
+
+    if Repositories.can_view_repository?(repository, conn.assigns.current_user) do
+      redirect(conn, external: "https://github.com/#{repository.owner}/#{repository.name}")
+    else
+      :not_found
+    end
+  end
+
   def edit(conn, %{"owner" => owner, "name" => name}) do
     repository = Repositories.get_repository_by_owner_and_name(owner, name)
 

--- a/lib/incentivize_web/plugs/require_stellar_key.ex
+++ b/lib/incentivize_web/plugs/require_stellar_key.ex
@@ -20,7 +20,10 @@ defmodule IncentivizeWeb.RequireStellarKey do
 
     if missing_stellar_key? && conn.request_path != Helpers.account_path(conn, :edit) do
       conn
-      |> Controller.put_flash(:error, "Please enter your Stellar public key")
+      |> Controller.put_flash(
+        :error,
+        "Please enter your Stellar public key before accessing this resource"
+      )
       |> Controller.redirect(to: Helpers.account_path(conn, :edit))
       |> halt
     else

--- a/lib/incentivize_web/router.ex
+++ b/lib/incentivize_web/router.ex
@@ -70,6 +70,9 @@ defmodule IncentivizeWeb.Router do
 
   pipeline :require_auth do
     plug(RequireAuth)
+  end
+
+  pipeline :require_stellar do
     plug(RequireStellarKey)
   end
 
@@ -111,10 +114,15 @@ defmodule IncentivizeWeb.Router do
     pipe_through([:browser, :require_auth])
 
     get("/", AccountController, :show)
-    get("/wallet", AccountController, :wallet)
     get("/edit", AccountController, :edit)
     put("/edit", AccountController, :update)
     get("/github/sync", AccountController, :sync)
+  end
+
+  scope "/account", IncentivizeWeb do
+    pipe_through([:browser, :require_auth, :require_stellar])
+
+    get("/wallet", AccountController, :wallet)
   end
 
   scope "/repos", IncentivizeWeb do
@@ -133,8 +141,14 @@ defmodule IncentivizeWeb.Router do
     put("/:owner/:name/edit", RepositoryController, :update)
   end
 
+  scope "/repos/:owner/:name/contribute", IncentivizeWeb do
+    pipe_through([:browser, :require_auth, :require_stellar])
+
+    get("/", RepositoryController, :contribute)
+  end
+
   scope "/repos/:owner/:name/funds", IncentivizeWeb do
-    pipe_through([:browser, :require_auth])
+    pipe_through([:browser, :require_auth, :require_stellar])
 
     get("/new", FundController, :new)
     post("/create", FundController, :create)

--- a/lib/incentivize_web/templates/repository/index.html.eex
+++ b/lib/incentivize_web/templates/repository/index.html.eex
@@ -65,7 +65,7 @@
                   <div class="rev-Col rev-Col--medium10">
                     <div class="rev-ButtonGroup u-flexAlignEnd">
                       <a class="rev-Button rev-Button--secondary" href="<%= fund_path(@conn, :new, repo.owner, repo.name) %>">Support Project</a>
-                      <a class="rev-Button" href="https://github.com/<%= repo.owner %>/<%= repo.name %>">
+                      <a class="rev-Button" href="<%= repository_path(@conn, :contribute, repo.owner, repo.name) %>">
                         Contribute
                       </a>
                     </div>

--- a/lib/incentivize_web/templates/repository/show.html.eex
+++ b/lib/incentivize_web/templates/repository/show.html.eex
@@ -26,8 +26,8 @@
     </p>
     <p><%= @stats.number_of_assets_distributed %> <%= Incentivize.Stellar.asset_display() %> Given</p>
 
-    <a class="rev-Button rev-Button--expanded Text-center" href="https://github.com/<%= @repository.owner %>/<%= @repository.name %>" target="_blank" rel="noreferrer">
-      Contribute on GitHub
+    <a class="rev-Button rev-Button--expanded Text-center" href="<%= repository_path(@conn, :contribute, @repository.owner, @repository.name) %>">
+      Contribute to this project
     </a>
     <a class="rev-Button rev-Button--expanded rev-Button--secondary Text-center" href="<%= fund_path(@conn, :new, @repository.owner, @repository.name) %>">
       Fund this project

--- a/test/incentivize_web/controllers/account_controller_test.exs
+++ b/test/incentivize_web/controllers/account_controller_test.exs
@@ -52,14 +52,14 @@ defmodule IncentivizeWeb.AccountControllerTest do
     assert html_response(conn, 400) =~ "Account"
   end
 
-  test "redirect to /account/edit when no stellar key defined" do
+  test "redirect to /account/wallet when no stellar key defined" do
     user = insert!(:user, stellar_public_key: nil)
 
     conn =
       build_conn()
       |> assign(:current_user, user)
 
-    conn = get(conn, account_path(conn, :show))
+    conn = get(conn, account_path(conn, :wallet))
     assert redirected_to(conn) =~ account_path(conn, :edit)
   end
 end

--- a/test/incentivize_web/controllers/repository_controller_test.exs
+++ b/test/incentivize_web/controllers/repository_controller_test.exs
@@ -59,6 +59,13 @@ defmodule IncentivizeWeb.RepositoryControllerTest do
     assert html_response(conn, 200) =~ "Hello World"
   end
 
+  test "GET /repos/:owner/:name/contribute", %{conn: conn} do
+    insert!(:repository, owner: "octocat", name: "Hello-World5")
+
+    conn = get(conn, repository_path(conn, :contribute, "octocat", "Hello-World5"))
+    assert redirected_to(conn) =~ "https://github.com"
+  end
+
   test "GET /repos/:owner/:name when repo private and user has access", %{conn: conn} do
     insert!(:repository, owner: "octocat", name: "Hello-World", public: false)
 


### PR DESCRIPTION
connect #253 

#### Description:
- Scope the need for a Stellar key for only routes that require it
- Make contribute button require stellar key for contributors

#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
